### PR TITLE
Install moveit_commander_cmdline.py into package specific directory, not to global bin.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,3 +6,7 @@ find_package(catkin)
 catkin_python_setup()
 
 catkin_package()
+
+install(DIRECTORY bin/
+        DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+        USE_SOURCE_PERMISSIONS)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,6 @@ from catkin_pkg.python_setup import generate_distutils_setup
 
 d = generate_distutils_setup()
 d['packages'] = ['moveit_commander']
-d['scripts'] = ['bin/moveit_commander_cmdline.py']
 d['package_dir'] = {'': 'src'}
 
 setup(**d)


### PR DESCRIPTION
[MoveIt! document](http://moveit.ros.org/wiki/MoveIt_Commander) expects `moveit_commander_cmdline.py` to be called via `rosrun`:

```
rosrun moveit_commander moveit_commander_cmdline.py
```

(There [was a question in answers](http://answers.ros.org/question/119151/cant-find-moveit-commander-exe-in-hydro/) that seems to have been deleted).

Indeed the python file is not placed in rosrun-able location.

```
$ find /opt/ros/hydro -iname moveit_commander_cmdline.py
/opt/ros/hydro/bin/moveit_commander_cmdline.py
```

Unless it's intended, installing scripts under each package folder is recommended in [catkin's doc](http://docs.ros.org/hydro/api/catkin/html/howto/installing_python.html), in addtion to the inconsistency with MoveIt! wiki I mentioned above.

```
ROS executables are installed in a per-package directory, not the distributions’s global bin/ directory. They are accessible to rosrun and roslaunch, without cluttering up the shell’s $PATH, and their names only need to be unique within each package. There are only a few core ROS commands like rosrun and roslaunch that install in the global bin/ directory.
```
