### PR TITLE
fix joint and link acces on __getattr__

### DIFF
--- a/src/moveit_commander/robot.py
+++ b/src/moveit_commander/robot.py
@@ -181,8 +181,8 @@ class RobotCommander(object):
         if name in self.get_group_names():
             return self.get_group(name)
         elif name in self.get_joint_names():
-            return self.Joint(name)
+            return self.Joint(self,name)
         elif name in self.get_link_names():
-            return self.Link(name)
+            return self.Link(self,name)
         else:
             return object.__getattribute__(self, name)


### PR DESCRIPTION
When trying to acces a joint and his paramaters through **getattribute**
there where missing a self in the function parameters. So it was not possible to acces directly through 
the RobotCommander to the joints or links parameters and crashes the program. This commit solves that.
