### PR TITLE
adding set_num_planning_attempts to commander interface

### DIFF
--- a/src/moveit_commander/move_group.py
+++ b/src/moveit_commander/move_group.py
@@ -376,6 +376,10 @@ class MoveGroupCommander(object):
         """ Specify which planner to use when motion planning """
         self._g.set_planner_id(planner_id)
 
+    def set_num_planning_attempts(self, num_planning_attempts):
+        """ Set the number of times the motion plan is to be computed from scratch before the shortest solution is returned. The default value is 1. """
+        self._g.set_num_planning_attempts(num_planning_attempts)
+
     def set_workspace(self, ws):
         """ Set the workspace for the robot as either [], [minX, minY, maxX, maxY] or [minX, minY, minZ, maxX, maxY, maxZ] """
         if len(ws) == 0:


### PR DESCRIPTION
This is a simple fix that allows the python interface to set the number of parallel planning attempts used by moveit. This will only work if this pull request: https://github.com/ros-planning/moveit_ros/pull/589 gets merged into moveit_ros. I have tested this code on a Baxter robot and it works fine. This pull request fixes this issue: https://github.com/ros-planning/moveit_commander/issues/34
