### PR TITLE
[RobotCommander] Fill in in-code document where missing.

### DIFF
--- a/src/moveit_commander/robot.py
+++ b/src/moveit_commander/robot.py
@@ -49,9 +49,20 @@ class RobotCommander(object):
             return self._name
 
         def variable_count(self):
+            """
+            @return number of the list that _Joint__get_joint_limits
+                    methods returns.
+            @see: http://docs.ros.org/indigo/api/moveit_core/html/classmoveit_1_1core_1_1JointModel.html#details
+                  for more about variable.
+            """
             return len(self.__get_joint_limits())
 
         def bounds(self):
+            """
+            @return: Either a single list of min and max joint limits, or
+                     a set of those lists, depending on the number of variables
+                     available in this joint.
+            """
             l = self.__get_joint_limits()
             if len(l) == 1:
                 return l[0]
@@ -59,6 +70,11 @@ class RobotCommander(object):
                 return l
 
         def min_bound(self):
+            """
+            @return: Either a single min joint limit value, or
+                     a set of min values, depending on the number of variables
+                     available in this joint.
+            """
             limits = self.__get_joint_limits()
             if len(limits) == 1:
                 return limits[0][0]
@@ -66,6 +82,11 @@ class RobotCommander(object):
                 return [l[0] for l in limits]
 
         def max_bound(self):
+            """
+            @return: Either a single max joint limit value, or
+                     a set of max values, depending on the number of variables
+                     available in this joint.
+            """
             limits = self.__get_joint_limits()
             if len(limits) == 1:
                 return limits[0][1]
@@ -73,6 +94,14 @@ class RobotCommander(object):
                 return [l[1] for l in limits]
 
         def value(self):
+            """
+            @rtype float
+
+            (Editor's comment by @130s) I doubt there's a case where this method goes into
+            "else" block, because get_current_joint_values always return a single list.
+
+            cf. getCurrentJointValues https://github.com/ros-planning/moveit_ros/blob/8e819dda2b19462b8d0c5aacc69706c8a9d8d883/planning_interface/robot_interface/src/wrap_python_robot_interface.cpp#L176
+            """
             vals = self._robot._r.get_current_joint_values(self._name)
             if len(vals) == 1:
                 return vals[0]
@@ -80,6 +109,10 @@ class RobotCommander(object):
                 return vals
 
         def move(self, position, wait=True):
+            """
+            @param position [float]: List of joint angles to achieve.
+            @param wait bool: If false, the commands gets operated asynchronously.
+            """
             group = self._robot.get_default_owner_group()
             if group is None:
                 raise MoveItCommanderException("There is no known group containing joint %s. Cannot move." % self._name)
@@ -91,6 +124,10 @@ class RobotCommander(object):
             return False
 
         def __get_joint_limits(self):
+            """
+            @return: A list of length of 2 that contains max and min positional
+                     limits of the specified joint.
+            """
             return self._robot._r.get_joint_limits(self._name)
 
     class Link(object):
@@ -102,6 +139,9 @@ class RobotCommander(object):
             return self._name
 
         def pose(self):
+            """
+            @rtype: geometry_msgs.Pose
+            """
             return conversions.list_to_pose_stamped(self._robot._r.get_link_pose(self._name), self._robot.get_planning_frame())
 
     def __init__(self):
@@ -166,18 +206,32 @@ class RobotCommander(object):
         return self._r.get_current_variable_values()
 
     def get_joint(self, name):
+        """
+        @param name str: Name of movegroup
+        @rtype: moveit_commander.robot.Joint
+        @raise exception: MoveItCommanderException
+        """
         if name in self.get_joint_names():
             return self.Joint(self, name)
         else:
             raise MoveItCommanderException("There is no joint named %s" % name)
 
     def get_link(self, name):
+        """
+        @param name str: Name of movegroup
+        @rtype: moveit_commander.robot.Link
+        @raise exception: MoveItCommanderException
+        """
         if name in self.get_link_names():
             return self.Link(self, name)
         else:
             raise MoveItCommanderException("There is no link named %s" % name)
 
     def get_group(self, name):
+        """
+        @param name str: Name of movegroup
+        @rtype: moveit_commander.MoveGroupCommander
+        """
         if not self._groups.has_key(name):
             if not self.has_group(name):
                 raise MoveItCommanderException("There is no group named %s" % name)
@@ -185,6 +239,10 @@ class RobotCommander(object):
         return self._groups[name]
 
     def has_group(self, name):
+        """
+        @param name str: Name of movegroup
+        @rtype: bool
+        """
         return self._r.has_group(name)
 
     def get_default_owner_group(self, joint_name):


### PR DESCRIPTION
- Added documents to methods where docs were absent.
- Loosely enforcing PEP8

Since I use `ipython` interpreter where methods' document can be referred to easily, I wanted to have more methods to show docs.
