### PR TITLE
Add the possibility to choose description file

### DIFF
--- a/src/moveit_commander/move_group.py
+++ b/src/moveit_commander/move_group.py
@@ -46,9 +46,9 @@ class MoveGroupCommander(object):
     Execution of simple commands for a particular group
     """
 
-    def __init__(self, name):
+    def __init__(self, name, robot_description="robot_description"):
         """ Specify the group name for which to construct this commander instance. Throws an exception if there is an initialization error. """
-        self._g = _moveit_move_group_interface.MoveGroup(name, "robot_description")
+        self._g = _moveit_move_group_interface.MoveGroup(name, robot_description)
 
     def get_name(self):
         """ Get the name of the group this instance was initialized for """

--- a/src/moveit_commander/robot.py
+++ b/src/moveit_commander/robot.py
@@ -144,8 +144,8 @@ class RobotCommander(object):
             """
             return conversions.list_to_pose_stamped(self._robot._r.get_link_pose(self._name), self._robot.get_planning_frame())
 
-    def __init__(self):
-        self._r = _moveit_robot_interface.RobotInterface("robot_description")
+    def __init__(self, robot_description="robot_description"):
+        self._r = _moveit_robot_interface.RobotInterface(robot_description)
         self._groups = {}
         self._joint_owner_group = {}
 


### PR DESCRIPTION
robot_description parameter should not be hardcoded to allow changing the name of
the description file. This is usefull when working with several robots
that do not share the same description file.

This change affects both robot_commander and move_group interfaces.
