### PR TITLE
workaround for #15, registrer exit command

### DIFF
--- a/src/moveit_commander/__init__.py
+++ b/src/moveit_commander/__init__.py
@@ -4,3 +4,7 @@ from planning_scene_interface import *
 from move_group import *
 from robot import *
 from interpreter import *
+
+# workaround for core dump whenever exiting Python MoveIt script (https://github.com/ros-planning/moveit_commander/issues/15#issuecomment-34441531)
+import atexit
+atexit.register(lambda : os._exit(0))


### PR DESCRIPTION
not sure if this is the correct fix, just a one proposal for workaround except adding `moveit_commander.os._exit(0)` for all of our program.
But i think we should try to find the root of the bug, may be some confront on binding roscpp on python ...
